### PR TITLE
fix: Removed primary key from billing report stream.

### DIFF
--- a/tap_sunwave/streams.py
+++ b/tap_sunwave/streams.py
@@ -161,7 +161,6 @@ class BillingReportStream(SunwaveStream):
 
     name = "billing_report"
     path = "/api/billing/arreport/from/{from}/until/{until}/billingentityid/{billingId}"
-    primary_keys = ("billing_entity_id",)
     replication_key = None
 
     @property


### PR DESCRIPTION
billing_entity_id can't be used a primary key as it is not unique. There isn't an ideal combination that can be used and it would be better to handle this via partitioning in upstream dbt models