### PR TITLE
fix: Incorrect primary key for census stream

### DIFF
--- a/tap_sunwave/streams.py
+++ b/tap_sunwave/streams.py
@@ -139,7 +139,6 @@ class CensusStream(SunwaveStream):
         {"census_status": "admitted"},
         {"census_status": "discharged"},
     ]
-    primary_keys = ("Account Id",)
     replication_key = None
 
     @override

--- a/tap_sunwave/streams.py
+++ b/tap_sunwave/streams.py
@@ -139,6 +139,7 @@ class CensusStream(SunwaveStream):
         {"census_status": "admitted"},
         {"census_status": "discharged"},
     ]
+    primary_keys = ("Admission Id",)
     replication_key = None
 
     @override


### PR DESCRIPTION
Using account id as a primary key results in us missing out on records, and 'admission id' results in distinct records which makes it a suitable candidate for a primary key