### PR TITLE
chore: Update Dependabot schedule intervals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: uv
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     commit-message:
       prefix: "fix(deps): "
       prefix-development: "chore(deps-dev): "
@@ -23,7 +23,7 @@ updates:
   - package-ecosystem: pip
     directory: "/.github/workflows"
     schedule:
-      interval: weekly
+      interval: quarterly
     commit-message:
       prefix: "ci: "
     groups:
@@ -33,7 +33,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: quarterly
     commit-message:
       prefix: "ci: "
     groups:


### PR DESCRIPTION
Changed the update schedule for uv, pip, and GitHub Actions packages from weekly to monthly or quarterly.